### PR TITLE
Fix/console log interceptor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Dependencias
 node_modules
 /webview/node_modules
-/webview
 
 # Archivos compilados
 out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the **Code2Context** extension will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2025-05-06
+
+### Fixed
+
+- ✅ Console interceptor ahora usa la API `console.subscribe` en lugar de parchar `console.log`, evitando interferir con otras extensiones.
+
 ## [0.1.1] - 2025-05-06
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "code2context",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "code2context",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "GPL-3.0",
       "dependencies": {
         "ignore": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "code2context",
   "displayName": "Code2Context",
   "description": "Generate compact code context for AI",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "engines": {
     "vscode": "^1.99.0"
   },


### PR DESCRIPTION
This pull request updates the `Code2Context` extension to version 0.1.2, introducing a significant improvement to how console logs are intercepted and forwarded to the WebView. The changes enhance compatibility with other extensions by using the `console.subscribe` API instead of monkey-patching `console.log`. Below is a summary of the most important changes:

### Enhancements to Console Log Interception

* [`src/adapters/primary/vscode/webview/ConsoleLogInterceptor.ts`](diffhunk://#diff-1294d0c7fa13e7b7100b90bace7e9d1aa7b574cf2e09edb2a4c8474498fbf8b0L7-R73): Refactored the `ConsoleLogInterceptor` class to use the `console.subscribe` API for listening to logs, ensuring compatibility with VS Code ≥ 1.88. This avoids modifying `console.log` directly, preventing interference with other extensions. Added fallback behavior to disable log interception gracefully if `console.subscribe` is unavailable.

### Version Update

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5): Updated the version of the extension from `0.1.1` to `0.1.2` to reflect the new changes.

### Documentation Update

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13): Documented the changes introduced in version 0.1.2, highlighting the switch to the `console.subscribe` API for better compatibility.