### PR TITLE
Fix/cleanup selection listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,57 +5,64 @@ All notable changes to the **Code2Context** extension will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2025-05-07
+
+### 🐞 Fixed in 0.1.4
+
+* 🔄 Prevent selection listener leak by unregistering WebviewProvider in `WebviewStateSynchronizer.dispose()` (#fix/cleanup-selection-listener)
+
 ## [0.1.3] - 2025-05-07
 
-### Changed
+### ✏️ Changed in 0.1.3
 
-- 📝 Streamlined Getting Started section in README: removed installation steps and simplified commands.
-- 🖼️ Added project screenshot to README.
+* 📝 Streamlined Getting Started section in README: removed installation steps and simplified commands.
+* 🖼️ Added project screenshot to README.
 
 ## [0.1.2] - 2025-05-06
 
-### Fixed
+### 🐞 Fixed in 0.1.2
 
-- ✅ Console interceptor ahora usa la API `console.subscribe` en lugar de parchar `console.log`, evitando interferir con otras extensiones.
+* ✅ Console interceptor ahora usa la API `console.subscribe` en lugar de parchar `console.log`, evitando interferir con otras extensiones.
 
 ## [0.1.1] - 2025-05-06
 
-### Changed
+### ✏️ Changed in 0.1.1
 
-- 🖼️ Added extension icon for better visibility in the VS Cod e Marketplace
+* 🖼️ Added extension icon for better visibility in the VS Code Marketplace
 
 ## [0.1.0] - 2025-05-04
 
-### Added
+### ✨ Added in 0.1.0
 
-- 🚀 **Initial Release** - First version of Code2Context!
-- 📁 Directory and file-based selection modes
-- 🖥️ WebView-based configuration panel with real-time updates
-- 🚫 Custom ignore patterns support
-- 📋 Integration with `.gitignore` files
-- ⚡ Content minification option for optimized output
-- 🌳 Project tree structure generation
-- 🤖 Multiple AI prompt presets:
-  - Deep Context V1 - Comprehensive context generation
-  - Architecture Review - Project structure analysis
-  - Bug Hunter - Find potential issues
-  - Documentation Generator - Auto-docs creation
-  - Refactor Guide - Code improvement plans
-- 💾 Large file handling (>10MB) with graceful degradation
-- 🔄 Real-time file selection synchronization
-- 🐛 Debug output panel for troubleshooting
-- ⚖️ GPL v3.0 license for complete freedom
+* 🚀 **Initial Release** - First version of Code2Context!
+* 📁 Directory and file-based selection modes
+* 🖥️ WebView-based configuration panel with real-time updates
+* 🚫 Custom ignore patterns support
+* 📋 Integration with `.gitignore` files
+* ⚡ Content minification option for optimized output
+* 🌳 Project tree structure generation
+* 🤖 Multiple AI prompt presets:
 
-### Fixed
+  * Deep Context V1 - Comprehensive context generation
+  * Architecture Review - Project structure analysis
+  * Bug Hunter - Find potential issues
+  * Documentation Generator - Auto-docs creation
+  * Refactor Guide - Code improvement plans
+* 💾 Large file handling (>10MB) with graceful degradation
+* 🔄 Real-time file selection synchronization
+* 🐛 Debug output panel for troubleshooting
+* ⚖️ GPL v3.0 license for complete freedom
 
-- N/A (First release)
+### 🐞 Fixed in 0.1.0
 
-### Security
+* N/A (First release)
 
-- Code distributed under GPL v3.0 for maximum transparency
+### 🔒 Security in 0.1.0
+
+* Code distributed under GPL v3.0 for maximum transparency
 
 ## Notes
 
-- This is the first public release of Code2Context
-- The extension is designed to work with VS Code ^1.85.0
-- All features are stable and ready for daily use
+* This is the first public release of Code2Context
+* The extension is designed to work with VS Code ^1.85.0
+* All features are stable and ready for daily use

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "code2context",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "code2context",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "license": "GPL-3.0",
       "dependencies": {
         "ignore": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "code2context",
   "displayName": "Code2Context",
   "description": "Generate compact code context for AI",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "engines": {
     "vscode": "^1.99.0"
   },

--- a/src/adapters/primary/vscode/services/selectionService.ts
+++ b/src/adapters/primary/vscode/services/selectionService.ts
@@ -114,7 +114,9 @@ export class VSCodeSelectionService implements SelectionPort {
     if (this.selectedFiles.length > 0) {
       this.selectedFiles = [];
       this.notifyListeners();
-      this.notificationService.showInformation(USER_MESSAGES.INFO.SELECTION_CLEARED);
+      this.notificationService.showInformation(
+        USER_MESSAGES.INFO.SELECTION_CLEARED
+      );
     }
   }
 
@@ -167,5 +169,10 @@ export class VSCodeSelectionService implements SelectionPort {
 
     // Limpiar selección
     this.selectedFiles = [];
+  }
+
+  /** Des-registra cualquier WebviewProvider previamente asignado */
+  unregisterWebviewProvider(): void {
+    this.webviewProvider = null;
   }
 }

--- a/src/adapters/primary/vscode/webview/WebviewStateSynchronizer.ts
+++ b/src/adapters/primary/vscode/webview/WebviewStateSynchronizer.ts
@@ -76,20 +76,14 @@ export class WebviewStateSynchronizer implements SelectionChangeListener {
   /**
    * Deja de escuchar los cambios y limpia los recursos.
    */
+  /** Deja de escuchar y libera recursos. */
   public dispose(): void {
     this.logger.info("Disposing WebviewStateSynchronizer resources.");
+
     this.optionsDisposable?.dispose();
     this.optionsDisposable = undefined;
 
-    // Cómo desregistrar de selectionService? No parece haber método público.
-    // Si selectionService se limpia al desactivar, podría ser suficiente.
-    // Por ahora, solo marcamos como no registrado.
-    if (this.selectionListenerRegistered) {
-      this.logger.warn(
-        "WebviewStateSynchronizer: No public method to unregister from selectionService. Listener might persist until deactivation."
-      );
-      // Idealmente, selectionService.unregisterWebviewProvider(this);
-      this.selectionListenerRegistered = false;
-    }
+    // ✅ Eliminamos el listener para evitar fugas
+    this.selectionService.unregisterWebviewProvider();
   }
 }

--- a/src/application/ports/driven/SelectionPort.ts
+++ b/src/application/ports/driven/SelectionPort.ts
@@ -75,4 +75,7 @@ export interface SelectionPort {
    * @returns `true` si el archivo queda seleccionado, `false` si se deselecciona.
    */
   toggleFileSelection(file: string): boolean;
+
+  /** Limpia el WebviewProvider registrado (si lo hubiera) */
+  unregisterWebviewProvider(): void;
 }


### PR DESCRIPTION
This pull request introduces a new version (0.1.4) of the Code2Context extension, addressing a memory leak issue and adding a new method for unregistering the WebviewProvider. Key changes include updates to the `CHANGELOG.md`, `package.json`, and several TypeScript files to implement and document the fix.

### Version Update and Documentation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R68): Added a new section for version 0.1.4, documenting the fix for a selection listener memory leak by unregistering the WebviewProvider in `WebviewStateSynchronizer.dispose()`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5): Updated the version number from 0.1.2 to 0.1.4.

### Code Fixes and Enhancements:

* `src/adapters/primary/vscode/services/selectionService.ts`: 
  - Added a new `unregisterWebviewProvider` method to clear the WebviewProvider reference.
  - Reformatted a notification message for better readability.

* [`src/adapters/primary/vscode/webview/WebviewStateSynchronizer.ts`](diffhunk://#diff-e97d50861ed1406f70939a10bf4fb7b164d092b2f97ee5f2a497fcf24d6e94cdR79-R87): Updated the `dispose` method to call `unregisterWebviewProvider` on the `selectionService`, ensuring proper cleanup of listeners and preventing memory leaks.

* [`src/application/ports/driven/SelectionPort.ts`](diffhunk://#diff-f088d93f45a88956a48a7a8527b46d8e4e7fd453f8f55cef3ece783899082c71R78-R80): Extended the `SelectionPort` interface with the new `unregisterWebviewProvider` method to support the cleanup functionality.